### PR TITLE
Made keywords ending with ';' still highlight

### DIFF
--- a/SqlSyntaxHighlighting/SqlClassifier.cs
+++ b/SqlSyntaxHighlighting/SqlClassifier.cs
@@ -12,7 +12,7 @@ namespace SqlSyntaxHighlighting
 	class SqlClassifier : IClassifier
 	{
 		private readonly char[] keywordPrefixCharacters = new[] { '\t', ' ', '"', '(' };
-		private readonly char[] keywordPostfixCharacters = new[] { '\t', ' ', '"', '(', ')' };
+		private readonly char[] keywordPostfixCharacters = new[] { '\t', ' ', '"', '(', ')', ';' };
 		private readonly char[] functionPrefixCharacters = new[] { '\t', ' ', '"', ',', '(' };
 		private readonly char[] functionPostfixCharacters = new[] { '\t', '(' };
 

--- a/SqlSyntaxHighlighting/source.extension.vsixmanifest
+++ b/SqlSyntaxHighlighting/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
 	<Identifier Id="SqlSyntaxHighlighting">
 		<Name>SQL Syntax Highlighting</Name>
 		<Author>Fabian de Groot</Author>
-		<Version>0.1.8.0</Version>
+		<Version>0.1.9.0</Version>
 		<Description xml:space="preserve">Adds basic SQL syntax highlighting (keywords, functions and variables) to string literals.</Description>
 		<Locale>1033</Locale>
 		<SupportedProducts>

--- a/SqlSyntaxHighlighting/source.extension.vsixmanifest
+++ b/SqlSyntaxHighlighting/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
 	<Identifier Id="SqlSyntaxHighlighting">
 		<Name>SQL Syntax Highlighting</Name>
 		<Author>Fabian de Groot</Author>
-		<Version>0.1.9.0</Version>
+		<Version>0.1.8.0</Version>
 		<Description xml:space="preserve">Adds basic SQL syntax highlighting (keywords, functions and variables) to string literals.</Description>
 		<Locale>1033</Locale>
 		<SupportedProducts>


### PR DESCRIPTION
e.g. BEGIN; now highlights the BEGIN keyword.